### PR TITLE
feat: Edit PublicButton

### DIFF
--- a/src/components/atoms/PublicButton.stories.tsx
+++ b/src/components/atoms/PublicButton.stories.tsx
@@ -10,30 +10,28 @@ storiesOf('components|atoms', module)
   .addDecorator(withKnobs)
   .add('PublicButton', () => (
     <View style={styles.container}>
+      {/* 기본 버튼 */}
       <PublicButton
-        buttonStyle={styles.button1}
-        textStyle={styles.buttonText1}
-        text={'토핑업 시작'}
-        onPressButton={action('onPress')}
-      />
-      <PublicButton
-        buttonStyle={styles.button2}
-        textStyle={styles.buttonText2}
-        text={'회원가입'}
-        onPressButton={action('onPress')}
-      />
-      <PublicButton
-        buttonStyle={styles.button3}
-        textStyle={styles.buttonText3}
-        text={'재전송'}
-        onPressButton={action('onPress')}
-      />
-      <PublicButton
-        buttonStyle={styles.button2}
-        textStyle={styles.buttonText2}
+        wrapperStyle={styles.mainButtonWrapper}
+        buttonStyle={styles.mainButton}
+        textStyle={styles.mainButtonText}
         text={'다음'}
         onPressButton={action('onPress')}
+      />
+      {/* 기본 버튼 - disabled */}
+      <PublicButton
+        buttonStyle={styles.button}
+        textStyle={styles.buttonText}
+        text={'disabled'}
+        onPressButton={action('onPress')}
         disabled
+      />
+      {/* 흰색 버튼 */}
+      <PublicButton
+        buttonStyle={styles.button}
+        textStyle={styles.buttonText}
+        text={'회원가입'}
+        onPressButton={action('onPress')}
       />
     </View>
   ));
@@ -43,30 +41,29 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'space-around',
   },
-  button1: {
-    backgroundColor: colors.MAIN,
+  mainButtonWrapper: {
+    justifyContent: 'center',
+    borderRadius: 12,
+    backgroundColor: colors.FFF,
     width: maxScale(320),
-    height: maxScale(52),
+    height: maxScale(60),
+    elevation: 5,
   },
-  buttonText1: {
+  mainButton: {
+    borderWidth: 2,
+    borderColor: colors.GRAY01,
+    backgroundColor: colors.MAIN,
+    width: maxScale(312),
+  },
+  mainButtonText: {
     color: colors.FFF,
   },
-  button2: {
+  button: {
     borderWidth: 1,
     borderColor: colors.GRAY05,
     width: maxScale(320),
-    height: maxScale(52),
   },
-  buttonText2: {
+  buttonText: {
     color: colors.GRAY02,
-  },
-  button3: {
-    borderWidth: 1,
-    borderColor: colors.GRAY05,
-    width: maxScale(240),
-    height: maxScale(40),
-  },
-  buttonText3: {
-    color: colors.GRAY03,
   },
 });

--- a/src/components/atoms/PublicButton.stories.tsx
+++ b/src/components/atoms/PublicButton.stories.tsx
@@ -10,28 +10,13 @@ storiesOf('components|atoms', module)
   .addDecorator(withKnobs)
   .add('PublicButton', () => (
     <View style={styles.container}>
-      {/* 기본 버튼 */}
-      <PublicButton
-        wrapperStyle={styles.mainButtonWrapper}
-        buttonStyle={styles.mainButton}
-        textStyle={styles.mainButtonText}
-        text={'다음'}
-        onPressButton={action('onPress')}
-      />
       {/* 기본 버튼 - disabled */}
       <PublicButton
         buttonStyle={styles.button}
         textStyle={styles.buttonText}
-        text={'disabled'}
-        onPressButton={action('onPress')}
+        title={'disabled'}
+        onPress={action('onPress')}
         disabled
-      />
-      {/* 흰색 버튼 */}
-      <PublicButton
-        buttonStyle={styles.button}
-        textStyle={styles.buttonText}
-        text={'회원가입'}
-        onPressButton={action('onPress')}
       />
     </View>
   ));
@@ -40,23 +25,6 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'space-around',
-  },
-  mainButtonWrapper: {
-    justifyContent: 'center',
-    borderRadius: 12,
-    backgroundColor: colors.FFF,
-    width: maxScale(320),
-    height: maxScale(60),
-    elevation: 5,
-  },
-  mainButton: {
-    borderWidth: 2,
-    borderColor: colors.GRAY01,
-    backgroundColor: colors.MAIN,
-    width: maxScale(312),
-  },
-  mainButtonText: {
-    color: colors.FFF,
   },
   button: {
     borderWidth: 1,

--- a/src/components/atoms/PublicButton.tsx
+++ b/src/components/atoms/PublicButton.tsx
@@ -6,22 +6,17 @@ import {
   TouchableOpacity,
   View,
   ViewStyle,
+  ButtonProps,
 } from 'react-native';
 import {colors, maxScale} from '~/constants/theme';
 
-export interface Props {
-  wrapperStyle?: ViewStyle;
-  buttonStyle?: ViewStyle;
+export interface Props extends ButtonProps {
+  buttonStyle: ViewStyle;
   textStyle?: TextStyle;
-  text: string;
   disabled?: boolean;
-  onPressButton: () => void;
 }
 
 const PublicButton = ({disabled = false, ...props}: Props) => {
-  const wrapperStyle = useMemo((): ViewStyle => {
-    return disabled ? {} : {...props.wrapperStyle};
-  }, [disabled, props.wrapperStyle]);
   const buttonStyle = useMemo(
     (): ViewStyle => ({
       ...props.buttonStyle,
@@ -39,14 +34,12 @@ const PublicButton = ({disabled = false, ...props}: Props) => {
   );
   return (
     <View style={styles.container}>
-      <View style={[wrapperStyle]}>
-        <TouchableOpacity
-          activeOpacity={0.7}
-          style={[buttonStyle, styles.button]}
-          disabled={disabled}>
-          <Text style={[textStyle, styles.text]}>{props.text}</Text>
-        </TouchableOpacity>
-      </View>
+      <TouchableOpacity
+        activeOpacity={0.7}
+        style={[buttonStyle, styles.button]}
+        disabled={disabled}>
+        <Text style={[textStyle, styles.text]}>{props.title}</Text>
+      </TouchableOpacity>
     </View>
   );
 };

--- a/src/components/atoms/PublicButton.tsx
+++ b/src/components/atoms/PublicButton.tsx
@@ -10,7 +10,7 @@ import {
 import {colors, maxScale} from '~/constants/theme';
 
 export interface Props {
-  containerStyle?: ViewStyle;
+  wrapperStyle?: ViewStyle;
   buttonStyle?: ViewStyle;
   textStyle?: TextStyle;
   text: string;
@@ -19,25 +19,27 @@ export interface Props {
 }
 
 const PublicButton = ({disabled = false, ...props}: Props) => {
-  const buttonStyle = useMemo((): ViewStyle => {
-    return {
+  const wrapperStyle = useMemo((): ViewStyle => {
+    return disabled ? {} : {...props.wrapperStyle};
+  }, [disabled, props.wrapperStyle]);
+  const buttonStyle = useMemo(
+    (): ViewStyle => ({
       ...props.buttonStyle,
       opacity: disabled ? 1 : undefined,
-      backgroundColor: disabled
-        ? colors.GRAY05
-        : props.buttonStyle.backgroundColor,
-    };
-  }, [disabled, props.buttonStyle]);
-
-  const textStyle = useMemo((): TextStyle => {
-    return {
+      backgroundColor: disabled ? colors.GRAY05 : colors.MAIN,
+    }),
+    [disabled, props.buttonStyle],
+  );
+  const textStyle = useMemo(
+    (): TextStyle => ({
       ...props.textStyle,
-      color: disabled ? colors.GRAY04 : props.textStyle.color,
-    };
-  }, [disabled, props.textStyle]);
+      color: disabled ? colors.GRAY04 : colors.FFF,
+    }),
+    [disabled, props.textStyle],
+  );
   return (
-    <>
-      <View style={[styles.container, props.containerStyle]}>
+    <View style={styles.container}>
+      <View style={[wrapperStyle]}>
         <TouchableOpacity
           activeOpacity={0.7}
           style={[buttonStyle, styles.button]}
@@ -45,18 +47,21 @@ const PublicButton = ({disabled = false, ...props}: Props) => {
           <Text style={[textStyle, styles.text]}>{props.text}</Text>
         </TouchableOpacity>
       </View>
-    </>
+    </View>
   );
 };
 
 export default PublicButton;
 
 const styles = StyleSheet.create({
-  container: {},
+  container: {
+    alignItems: 'center',
+  },
   button: {
-    borderRadius: 8,
+    borderRadius: 12,
     alignSelf: 'center',
     justifyContent: 'center',
+    height: maxScale(52),
   },
   text: {
     alignSelf: 'center',

--- a/src/components/molecules/MainButton.stories.tsx
+++ b/src/components/molecules/MainButton.stories.tsx
@@ -1,0 +1,22 @@
+import {action} from '@storybook/addon-actions';
+import {withKnobs} from '@storybook/addon-knobs';
+import {storiesOf} from '@storybook/react-native';
+import React from 'react';
+import {View, StyleSheet} from 'react-native';
+// import {colors, maxScale} from '~/constants/theme';
+import MainButton from './MainButton';
+
+storiesOf('components|molecules', module)
+  .addDecorator(withKnobs)
+  .add('MainButton', () => (
+    <View style={styles.container}>
+      <MainButton title={'다음'} onPress={action('onPress')} />
+    </View>
+  ));
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+  },
+});

--- a/src/components/molecules/MainButton.tsx
+++ b/src/components/molecules/MainButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {StyleSheet, ButtonProps, View} from 'react-native';
+import PublicButton from '@components/atoms/PublicButton';
+import {colors, maxScale} from '~/constants/theme';
+
+interface Props extends ButtonProps {}
+
+const MainButton = ({...props}: Props) => {
+  return (
+    <View style={styles.wrapper}>
+      <PublicButton
+        buttonStyle={styles.button}
+        textStyle={styles.buttonText}
+        {...props}
+      />
+    </View>
+  );
+};
+
+export default MainButton;
+
+const styles = StyleSheet.create({
+  wrapper: {
+    justifyContent: 'center',
+    borderRadius: 12,
+    backgroundColor: colors.FFF,
+    width: maxScale(320),
+    height: maxScale(60),
+    elevation: 5,
+  },
+  button: {
+    borderWidth: 2,
+    borderColor: colors.GRAY01,
+    backgroundColor: colors.MAIN,
+    width: maxScale(312),
+  },
+  buttonText: {
+    color: colors.FFF,
+  },
+});

--- a/storybook/storyLoader.js
+++ b/storybook/storyLoader.js
@@ -6,6 +6,7 @@
 function loadStories() {
   require('../src/components/atoms/PublicButton.stories');
   require('../src/components/atoms/PublicTextInput.stories');
+  require('../src/components/molecules/MainButton.stories');
   require('../src/components/templates/AuthLoadingTemplate.stories');
   require('../src/components/templates/HomeTemplate.stories');
 }
@@ -13,6 +14,7 @@ function loadStories() {
 const stories = [
   '../src/components/atoms/PublicButton.stories',
   '../src/components/atoms/PublicTextInput.stories',
+  '../src/components/molecoules/MainButton.stories',
   '../src/components/templates/AuthLoadingTemplate.stories',
   '../src/components/templates/HomeTemplate.stories',
 ];


### PR DESCRIPTION
회원가입 화면에서 사용되는 mainButton, disabledButton(, button) 세가지 종류입니다.
mainButton이 좀 특이해서 지난번에 카톡방에서 이야기한대로 따로 molecule 레벨로 만드려고 했었는데,
한편으로 disabled같은 prop을 같은 컴포넌트에 내리는게 좋지 않나 싶어서 mainButton을 위한 wrapper 스타일을 추가했습니다.

PublicButton을 사용하는 부모 컴포넌트에서 disabled 여부에 따라 wrapperStyle을 내릴지 말지 분기를 쳐줘야겠다고 생각한건데, 
더 이상 좋은 방법을 못찾고있습니다.

리뷰해주시고 더 나은 아이디어 있으면 부탁드릴게요!
